### PR TITLE
[Update] support "clip input region"

### DIFF
--- a/combine.go
+++ b/combine.go
@@ -32,3 +32,27 @@ func combine(xMin, xMax, yMin, yMax, z int, config MapConfig) error {
 	}
 	return nil
 }
+
+func clip(xMinRatio, xMaxRatio, yMinRatio, yMaxRatio float64, z int, config MapConfig) error {
+	fmt.Println(getClippedPicPath(config, z))
+
+	im, err := gg.LoadImage(getCombinePicPath(config, z))
+	if err != nil {
+		return err
+	}
+
+	size := im.Bounds().Size()
+	imageWidth := float64(size.X)
+	imageHeight := float64(size.Y)
+	canvasWidth := int((xMaxRatio - xMinRatio) * imageWidth)
+	canvasHeight := int((yMaxRatio - yMinRatio) * imageHeight)
+
+	overview := gg.NewContext(canvasWidth, canvasHeight)
+	overview.DrawImageAnchored(im, 0, 0, xMinRatio, yMinRatio)
+
+	err = overview.SavePNG(getClippedPicPath(config, z))
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -122,6 +122,13 @@ func main() {
 		if err != nil {
 			fmt.Printf("combine pic error: %+v\n", err)
 		}
+
+		if config.Clip {
+			err = clipRegion(leftTileX, rightTileX, topTileY, bottomTileY, z, perTileWidth, config, leftTop, rightBottom)
+			if err != nil {
+				fmt.Printf("clip pic error: %+v\n", err)
+			}
+		}
 	}
 }
 
@@ -148,4 +155,21 @@ func getCombinePicPath(config MapConfig, z int) string {
 	return strings.Join([]string{
 		config.SavePath, config.MapType, "level_" + strconv.Itoa(z),
 	}, string(filepath.Separator)) + ".jpg"
+}
+
+func getClippedPicPath(config MapConfig, z int) string {
+	return strings.Join([]string{
+		config.SavePath, config.MapType, "level_" + strconv.Itoa(z),
+	}, string(filepath.Separator)) + ".clipped.jpg"
+}
+
+func clipRegion(xMin, xMax, yMin, yMax, z int, perTileWidth float64, config MapConfig, leftTop, rightBottom coordinate.Coordinate) error {
+	dx := float64(xMax-xMin+1) * perTileWidth
+	dy := float64(yMax-yMin+1) * perTileWidth
+	xMinRatio := (leftTop.X - float64(xMin)*perTileWidth) / dx
+	xMaxRatio := (rightBottom.X - float64(xMin)*perTileWidth) / dx
+	yMinRatio := (leftTop.Y - float64(yMin)*perTileWidth) / dy
+	yMaxRatio := (rightBottom.Y - float64(yMin)*perTileWidth) / dy
+
+	return clip(xMinRatio, xMaxRatio, yMinRatio, yMaxRatio, z, config)
 }

--- a/parse.go
+++ b/parse.go
@@ -12,6 +12,8 @@ type MapConfig struct {
 	SavePath string
 	// Combine put same level map together
 	Combine bool
+	// Whether to clip input region from the result image
+	Clip bool
 	// QPS query file speed per second
 	QPS int
 
@@ -48,6 +50,7 @@ func parseMapConfig() MapConfig {
 	flag.StringVar(&conf.SavePath, "p", "/tmp", "map save path")
 	flag.IntVar(&conf.GoroutineNum, "g", 50, "goroutine nums")
 	flag.BoolVar(&conf.Combine, "c", true, "combine same level map together")
+	flag.BoolVar(&conf.Clip, "clip", false, "clip input region from the result image")
 	flag.IntVar(&conf.QPS, "q", 500, "query file per second number")
 
 	flag.Float64Var(&conf.LeftLongitude, "l", 0, "left longitude")


### PR DESCRIPTION
我注意到目前拼接出来的图像是所给经纬度区域包含的所有块直接拼接，会一定程度上包含给定区域之外的部分，因此希望有一个选项能支持裁剪输出结果至只包含用户指定区域的图像。
该pr实现了从拼接的结果图中裁剪掉多余的区域，得到匹配指定范围的图像的功能，通过-clip参数指定，为保持兼容性默认为false。
如果有其它需要修改的部分欢迎随时通知我。: )

I noticed that current output image is a direct combination of all blocks involved, which leads to redundent area that may not be expected. Thus any option to clip exactly specified region from output may be useful.
This pr implemented support for clipping the exact region from combined image, and added a related option `-clip` which defaults to `false` for compatibility.
Please let me know if any improvement is required. :) 